### PR TITLE
enable soong tests during building

### DIFF
--- a/bazel/properties.go
+++ b/bazel/properties.go
@@ -175,6 +175,7 @@ const (
 	ARCH_ARM64  = "arm64"
 	ARCH_X86    = "x86"
 	ARCH_X86_64 = "x86_64"
+	ARCH_RISCV64 = "riscv64"
 
 	// OsType names in arch.go
 	OS_ANDROID      = "android"
@@ -207,6 +208,7 @@ var (
 		ARCH_ARM64:         "//build/bazel/platforms/arch:arm64",
 		ARCH_X86:           "//build/bazel/platforms/arch:x86",
 		ARCH_X86_64:        "//build/bazel/platforms/arch:x86_64",
+		ARCH_RISCV64:	    "//build/bazel/platforms/arch:riscv64",
 		CONDITIONS_DEFAULT: "//conditions:default", // The default condition of as arch select map.
 	}
 
@@ -229,11 +231,12 @@ type Attribute interface {
 
 // Represents an attribute whose value is a single label
 type LabelAttribute struct {
-	Value  Label
-	X86    Label
-	X86_64 Label
-	Arm    Label
-	Arm64  Label
+	Value   Label
+	X86     Label
+	X86_64  Label
+	Arm     Label
+	Arm64   Label
+	Riscv64 Label
 }
 
 func (attr *LabelAttribute) GetValueForArch(arch string) Label {
@@ -246,6 +249,8 @@ func (attr *LabelAttribute) GetValueForArch(arch string) Label {
 		return attr.X86
 	case ARCH_X86_64:
 		return attr.X86_64
+	case ARCH_RISCV64:
+		return attr.Riscv64
 	case CONDITIONS_DEFAULT:
 		return attr.Value
 	default:
@@ -263,23 +268,26 @@ func (attr *LabelAttribute) SetValueForArch(arch string, value Label) {
 		attr.X86 = value
 	case ARCH_X86_64:
 		attr.X86_64 = value
+	case ARCH_RISCV64:
+		attr.Riscv64 = value
 	default:
 		panic("Invalid arch type")
 	}
 }
 
 func (attr LabelAttribute) HasConfigurableValues() bool {
-	return attr.Arm.Label != "" || attr.Arm64.Label != "" || attr.X86.Label != "" || attr.X86_64.Label != ""
+	return attr.Arm.Label != "" || attr.Arm64.Label != "" || attr.X86.Label != "" || attr.X86_64.Label != "" || attr.Riscv64.Label != ""
 }
 
 // Arch-specific label_list typed Bazel attribute values. This should correspond
 // to the types of architectures supported for compilation in arch.go.
 type labelListArchValues struct {
-	X86    LabelList
-	X86_64 LabelList
-	Arm    LabelList
-	Arm64  LabelList
-	Common LabelList
+	X86     LabelList
+	X86_64  LabelList
+	Arm     LabelList
+	Arm64   LabelList
+	Riscv64 LabelList
+	Common  LabelList
 
 	ConditionsDefault LabelList
 }
@@ -360,6 +368,7 @@ func (attrs *LabelListAttribute) archValuePtrs() map[string]*LabelList {
 		ARCH_X86_64:        &attrs.ArchValues.X86_64,
 		ARCH_ARM:           &attrs.ArchValues.Arm,
 		ARCH_ARM64:         &attrs.ArchValues.Arm64,
+		ARCH_RISCV64:	    &attrs.ArchValues.Riscv64,
 		CONDITIONS_DEFAULT: &attrs.ArchValues.ConditionsDefault,
 	}
 }
@@ -438,11 +447,12 @@ func MakeStringListAttribute(value []string) StringListAttribute {
 // Arch-specific string_list typed Bazel attribute values. This should correspond
 // to the types of architectures supported for compilation in arch.go.
 type stringListArchValues struct {
-	X86    []string
-	X86_64 []string
-	Arm    []string
-	Arm64  []string
-	Common []string
+	X86     []string
+	X86_64  []string
+	Arm     []string
+	Arm64   []string
+	Riscv64 []string
+	Common  []string
 
 	ConditionsDefault []string
 }
@@ -481,6 +491,7 @@ func (attrs *StringListAttribute) archValuePtrs() map[string]*[]string {
 		ARCH_X86_64:        &attrs.ArchValues.X86_64,
 		ARCH_ARM:           &attrs.ArchValues.Arm,
 		ARCH_ARM64:         &attrs.ArchValues.Arm64,
+		ARCH_RISCV64:	    &attrs.ArchValues.Riscv64,
 		CONDITIONS_DEFAULT: &attrs.ArchValues.ConditionsDefault,
 	}
 }

--- a/bp2build/cc_library_headers_conversion_test.go
+++ b/bp2build/cc_library_headers_conversion_test.go
@@ -15,90 +15,91 @@
 package bp2build
 
 import (
-	"android/soong/android"
-	"android/soong/cc"
-	"strings"
-	"testing"
+    "android/soong/android"
+    "android/soong/cc"
+    "strings"
+    "testing"
 )
 
 const (
-	// See cc/testing.go for more context
-	soongCcLibraryHeadersPreamble = `
+    // See cc/testing.go for more context
+    soongCcLibraryHeadersPreamble = `
 cc_defaults {
-	name: "linux_bionic_supported",
+    name: "linux_bionic_supported",
 }
 
 toolchain_library {
-	name: "libclang_rt.builtins-x86_64-android",
-	defaults: ["linux_bionic_supported"],
-	vendor_available: true,
-	vendor_ramdisk_available: true,
-	product_available: true,
-	recovery_available: true,
-	native_bridge_supported: true,
-	src: "",
+    name: "libclang_rt.builtins-x86_64-android",
+    defaults: ["linux_bionic_supported"],
+    vendor_available: true,
+    vendor_ramdisk_available: true,
+    product_available: true,
+    recovery_available: true,
+    native_bridge_supported: true,
+    src: "",
 }`
 )
 
 func TestCcLibraryHeadersLoadStatement(t *testing.T) {
-	testCases := []struct {
-		bazelTargets           BazelTargets
-		expectedLoadStatements string
-	}{
-		{
-			bazelTargets: BazelTargets{
-				BazelTarget{
-					name:      "cc_library_headers_target",
-					ruleClass: "cc_library_headers",
-					// Note: no bzlLoadLocation for native rules
-				},
-			},
-			expectedLoadStatements: ``,
-		},
-	}
+    testCases := []struct {
+        bazelTargets           BazelTargets
+        expectedLoadStatements string
+    }{
+        {
+            bazelTargets: BazelTargets{
+                BazelTarget{
+                    name:      "cc_library_headers_target",
+                    ruleClass: "cc_library_headers",
+                    // Note: no bzlLoadLocation for native rules
+                },
+            },
+            expectedLoadStatements: ``,
+        },
+    }
 
-	for _, testCase := range testCases {
-		actual := testCase.bazelTargets.LoadStatements()
-		expected := testCase.expectedLoadStatements
-		if actual != expected {
-			t.Fatalf("Expected load statements to be %s, got %s", expected, actual)
-		}
-	}
+    for _, testCase := range testCases {
+        actual := testCase.bazelTargets.LoadStatements()
+        expected := testCase.expectedLoadStatements
+        if actual != expected {
+            t.Fatalf("Expected load statements to be %s, got %s", expected, actual)
+        }
+    }
 
 }
 
 func TestCcLibraryHeadersBp2Build(t *testing.T) {
-	testCases := []struct {
-		description                        string
-		moduleTypeUnderTest                string
-		moduleTypeUnderTestFactory         android.ModuleFactory
-		moduleTypeUnderTestBp2BuildMutator func(android.TopDownMutatorContext)
-		preArchMutators                    []android.RegisterMutatorFunc
-		depsMutators                       []android.RegisterMutatorFunc
-		bp                                 string
-		expectedBazelTargets               []string
-		filesystem                         map[string]string
-		dir                                string
-	}{
-		{
-			description:                        "cc_library_headers test",
-			moduleTypeUnderTest:                "cc_library_headers",
-			moduleTypeUnderTestFactory:         cc.LibraryHeaderFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryHeadersBp2Build,
-			filesystem: map[string]string{
-				"lib-1/lib1a.h":                        "",
-				"lib-1/lib1b.h":                        "",
-				"lib-2/lib2a.h":                        "",
-				"lib-2/lib2b.h":                        "",
-				"dir-1/dir1a.h":                        "",
-				"dir-1/dir1b.h":                        "",
-				"dir-2/dir2a.h":                        "",
-				"dir-2/dir2b.h":                        "",
-				"arch_arm64_exported_include_dir/a.h":  "",
-				"arch_x86_exported_include_dir/b.h":    "",
-				"arch_x86_64_exported_include_dir/c.h": "",
-			},
-			bp: soongCcLibraryHeadersPreamble + `
+    testCases := []struct {
+        description                        string
+        moduleTypeUnderTest                string
+        moduleTypeUnderTestFactory         android.ModuleFactory
+        moduleTypeUnderTestBp2BuildMutator func(android.TopDownMutatorContext)
+        preArchMutators                    []android.RegisterMutatorFunc
+        depsMutators                       []android.RegisterMutatorFunc
+        bp                                 string
+        expectedBazelTargets               []string
+        filesystem                         map[string]string
+        dir                                string
+    }{
+        {
+            description:                        "cc_library_headers test",
+            moduleTypeUnderTest:                "cc_library_headers",
+            moduleTypeUnderTestFactory:         cc.LibraryHeaderFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryHeadersBp2Build,
+            filesystem: map[string]string{
+                "lib-1/lib1a.h":                        "",
+                "lib-1/lib1b.h":                        "",
+                "lib-2/lib2a.h":                        "",
+                "lib-2/lib2b.h":                        "",
+                "dir-1/dir1a.h":                        "",
+                "dir-1/dir1b.h":                        "",
+                "dir-2/dir2a.h":                        "",
+                "dir-2/dir2b.h":                        "",
+                "arch_arm64_exported_include_dir/a.h":  "",
+                "arch_x86_exported_include_dir/b.h":    "",
+                "arch_x86_64_exported_include_dir/c.h": "",
+                "arch_riscv64_exported_include_dir/d.h":"",
+            },
+            bp: soongCcLibraryHeadersPreamble + `
 cc_library_headers {
     name: "lib-1",
     export_include_dirs: ["lib-1"],
@@ -116,7 +117,7 @@ cc_library_headers {
 
     arch: {
         arm64: {
-	    // We expect dir-1 headers to be dropped, because dir-1 is already in export_include_dirs
+        // We expect dir-1 headers to be dropped, because dir-1 is already in export_include_dirs
             export_include_dirs: ["arch_arm64_exported_include_dir", "dir-1"],
         },
         x86: {
@@ -125,11 +126,14 @@ cc_library_headers {
         x86_64: {
             export_include_dirs: ["arch_x86_64_exported_include_dir"],
         },
+        riscv64: {
+            export_include_dirs: ["arch_riscv64_exported_include_dir"],
+        },
     },
 
     // TODO: Also support export_header_lib_headers
 }`,
-			expectedBazelTargets: []string{`cc_library_headers(
+            expectedBazelTargets: []string{`cc_library_headers(
     name = "foo_headers",
     copts = ["-I."],
     deps = [
@@ -141,6 +145,7 @@ cc_library_headers {
         "dir-2",
     ] + select({
         "//build/bazel/platforms/arch:arm64": ["arch_arm64_exported_include_dir"],
+        "//build/bazel/platforms/arch:riscv64": ["arch_riscv64_exported_include_dir"],
         "//build/bazel/platforms/arch:x86": ["arch_x86_exported_include_dir"],
         "//build/bazel/platforms/arch:x86_64": ["arch_x86_64_exported_include_dir"],
         "//conditions:default": [],
@@ -154,15 +159,15 @@ cc_library_headers {
     copts = ["-I."],
     includes = ["lib-2"],
 )`},
-		},
-		{
-			description:                        "cc_library_headers test with os-specific header_libs props",
-			moduleTypeUnderTest:                "cc_library_headers",
-			moduleTypeUnderTestFactory:         cc.LibraryHeaderFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryHeadersBp2Build,
-			depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
-			filesystem:                         map[string]string{},
-			bp: soongCcLibraryPreamble + `
+        },
+        {
+            description:                        "cc_library_headers test with os-specific header_libs props",
+            moduleTypeUnderTest:                "cc_library_headers",
+            moduleTypeUnderTestFactory:         cc.LibraryHeaderFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryHeadersBp2Build,
+            depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
+            filesystem:                         map[string]string{},
+            bp: soongCcLibraryPreamble + `
 cc_library_headers { name: "android-lib" }
 cc_library_headers { name: "base-lib" }
 cc_library_headers { name: "darwin-lib" }
@@ -183,7 +188,7 @@ cc_library_headers {
     },
     bazel_module: { bp2build_available: true },
 }`,
-			expectedBazelTargets: []string{`cc_library_headers(
+            expectedBazelTargets: []string{`cc_library_headers(
     name = "android-lib",
     copts = ["-I."],
 )`, `cc_library_headers(
@@ -217,15 +222,15 @@ cc_library_headers {
     name = "windows-lib",
     copts = ["-I."],
 )`},
-		},
-		{
-			description:                        "cc_library_headers test with os-specific header_libs and export_header_lib_headers props",
-			moduleTypeUnderTest:                "cc_library_headers",
-			moduleTypeUnderTestFactory:         cc.LibraryHeaderFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryHeadersBp2Build,
-			depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
-			filesystem:                         map[string]string{},
-			bp: soongCcLibraryPreamble + `
+        },
+        {
+            description:                        "cc_library_headers test with os-specific header_libs and export_header_lib_headers props",
+            moduleTypeUnderTest:                "cc_library_headers",
+            moduleTypeUnderTestFactory:         cc.LibraryHeaderFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryHeadersBp2Build,
+            depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
+            filesystem:                         map[string]string{},
+            bp: soongCcLibraryPreamble + `
 cc_library_headers { name: "android-lib" }
 cc_library_headers { name: "exported-lib" }
 cc_library_headers {
@@ -234,7 +239,7 @@ cc_library_headers {
         android: { header_libs: ["android-lib"], export_header_lib_headers: ["exported-lib"] },
     },
 }`,
-			expectedBazelTargets: []string{`cc_library_headers(
+            expectedBazelTargets: []string{`cc_library_headers(
     name = "android-lib",
     copts = ["-I."],
 )`, `cc_library_headers(
@@ -251,25 +256,25 @@ cc_library_headers {
         "//conditions:default": [],
     }),
 )`},
-		},
-		{
-			description:                        "cc_library_headers test with arch-specific and target-specific export_system_include_dirs props",
-			moduleTypeUnderTest:                "cc_library_headers",
-			moduleTypeUnderTestFactory:         cc.LibraryHeaderFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryHeadersBp2Build,
-			depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
-			filesystem:                         map[string]string{},
-			bp: soongCcLibraryPreamble + `cc_library_headers {
+        },
+        {
+            description:                        "cc_library_headers test with arch-specific and target-specific export_system_include_dirs props",
+            moduleTypeUnderTest:                "cc_library_headers",
+            moduleTypeUnderTestFactory:         cc.LibraryHeaderFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryHeadersBp2Build,
+            depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
+            filesystem:                         map[string]string{},
+            bp: soongCcLibraryPreamble + `cc_library_headers {
     name: "foo_headers",
     export_system_include_dirs: [
-	"shared_include_dir",
+    "shared_include_dir",
     ],
     target: {
-	android: {
-	    export_system_include_dirs: [
-		"android_include_dir",
+    android: {
+        export_system_include_dirs: [
+        "android_include_dir",
             ],
-	},
+    },
         linux_glibc: {
             export_system_include_dirs: [
                 "linux_include_dir",
@@ -283,10 +288,15 @@ cc_library_headers {
     },
     arch: {
         arm: {
-	    export_system_include_dirs: [
-		"arm_include_dir",
+        export_system_include_dirs: [
+        "arm_include_dir",
             ],
-	},
+    },
+        riscv64: {
+                export_system_include_dirs: [
+                    "riscv64_include_dir",
+                ],
+            },
         x86_64: {
             export_system_include_dirs: [
                 "x86_64_include_dir",
@@ -294,11 +304,12 @@ cc_library_headers {
         },
     },
 }`,
-			expectedBazelTargets: []string{`cc_library_headers(
+            expectedBazelTargets: []string{`cc_library_headers(
     name = "foo_headers",
     copts = ["-I."],
     includes = ["shared_include_dir"] + select({
         "//build/bazel/platforms/arch:arm": ["arm_include_dir"],
+        "//build/bazel/platforms/arch:riscv64": ["riscv64_include_dir"],
         "//build/bazel/platforms/arch:x86_64": ["x86_64_include_dir"],
         "//conditions:default": [],
     }) + select({
@@ -308,65 +319,65 @@ cc_library_headers {
         "//conditions:default": [],
     }),
 )`},
-		},
-	}
+        },
+    }
 
-	dir := "."
-	for _, testCase := range testCases {
-		filesystem := make(map[string][]byte)
-		toParse := []string{
-			"Android.bp",
-		}
-		for f, content := range testCase.filesystem {
-			if strings.HasSuffix(f, "Android.bp") {
-				toParse = append(toParse, f)
-			}
-			filesystem[f] = []byte(content)
-		}
-		config := android.TestConfig(buildDir, nil, testCase.bp, filesystem)
-		ctx := android.NewTestContext(config)
+    dir := "."
+    for _, testCase := range testCases {
+        filesystem := make(map[string][]byte)
+        toParse := []string{
+            "Android.bp",
+        }
+        for f, content := range testCase.filesystem {
+            if strings.HasSuffix(f, "Android.bp") {
+                toParse = append(toParse, f)
+            }
+            filesystem[f] = []byte(content)
+        }
+        config := android.TestConfig(buildDir, nil, testCase.bp, filesystem)
+        ctx := android.NewTestContext(config)
 
-		// TODO(jingwen): make this default for all bp2build tests
-		ctx.RegisterBp2BuildConfig(bp2buildConfig)
+        // TODO(jingwen): make this default for all bp2build tests
+        ctx.RegisterBp2BuildConfig(bp2buildConfig)
 
-		cc.RegisterCCBuildComponents(ctx)
-		ctx.RegisterModuleType("toolchain_library", cc.ToolchainLibraryFactory)
+        cc.RegisterCCBuildComponents(ctx)
+        ctx.RegisterModuleType("toolchain_library", cc.ToolchainLibraryFactory)
 
-		ctx.RegisterModuleType(testCase.moduleTypeUnderTest, testCase.moduleTypeUnderTestFactory)
-		for _, m := range testCase.depsMutators {
-			ctx.DepsBp2BuildMutators(m)
-		}
-		ctx.RegisterBp2BuildMutator(testCase.moduleTypeUnderTest, testCase.moduleTypeUnderTestBp2BuildMutator)
-		ctx.RegisterForBazelConversion()
+        ctx.RegisterModuleType(testCase.moduleTypeUnderTest, testCase.moduleTypeUnderTestFactory)
+        for _, m := range testCase.depsMutators {
+            ctx.DepsBp2BuildMutators(m)
+        }
+        ctx.RegisterBp2BuildMutator(testCase.moduleTypeUnderTest, testCase.moduleTypeUnderTestBp2BuildMutator)
+        ctx.RegisterForBazelConversion()
 
-		_, errs := ctx.ParseFileList(dir, toParse)
-		if Errored(t, testCase.description, errs) {
-			continue
-		}
-		_, errs = ctx.ResolveDependencies(config)
-		if Errored(t, testCase.description, errs) {
-			continue
-		}
+        _, errs := ctx.ParseFileList(dir, toParse)
+        if Errored(t, testCase.description, errs) {
+            continue
+        }
+        _, errs = ctx.ResolveDependencies(config)
+        if Errored(t, testCase.description, errs) {
+            continue
+        }
 
-		checkDir := dir
-		if testCase.dir != "" {
-			checkDir = testCase.dir
-		}
-		codegenCtx := NewCodegenContext(config, *ctx.Context, Bp2Build)
-		bazelTargets := generateBazelTargetsForDir(codegenCtx, checkDir)
-		if actualCount, expectedCount := len(bazelTargets), len(testCase.expectedBazelTargets); actualCount != expectedCount {
-			t.Errorf("%s: Expected %d bazel target, got %d", testCase.description, expectedCount, actualCount)
-		} else {
-			for i, target := range bazelTargets {
-				if w, g := testCase.expectedBazelTargets[i], target.content; w != g {
-					t.Errorf(
-						"%s: Expected generated Bazel target to be '%s', got '%s'",
-						testCase.description,
-						w,
-						g,
-					)
-				}
-			}
-		}
-	}
+        checkDir := dir
+        if testCase.dir != "" {
+            checkDir = testCase.dir
+        }
+        codegenCtx := NewCodegenContext(config, *ctx.Context, Bp2Build)
+        bazelTargets := generateBazelTargetsForDir(codegenCtx, checkDir)
+        if actualCount, expectedCount := len(bazelTargets), len(testCase.expectedBazelTargets); actualCount != expectedCount {
+            t.Errorf("%s: Expected %d bazel target, got %d", testCase.description, expectedCount, actualCount)
+        } else {
+            for i, target := range bazelTargets {
+                if w, g := testCase.expectedBazelTargets[i], target.content; w != g {
+                    t.Errorf(
+                        "%s: Expected generated Bazel target to be '%s', got '%s'",
+                        testCase.description,
+                        w,
+                        g,
+                    )
+                }
+            }
+        }
+    }
 }

--- a/bp2build/cc_library_static_conversion_test.go
+++ b/bp2build/cc_library_static_conversion_test.go
@@ -15,97 +15,97 @@
 package bp2build
 
 import (
-	"android/soong/android"
-	"android/soong/cc"
-	"strings"
-	"testing"
+    "android/soong/android"
+    "android/soong/cc"
+    "strings"
+    "testing"
 )
 
 const (
-	// See cc/testing.go for more context
-	soongCcLibraryStaticPreamble = `
+    // See cc/testing.go for more context
+    soongCcLibraryStaticPreamble = `
 cc_defaults {
-	name: "linux_bionic_supported",
+    name: "linux_bionic_supported",
 }
 
 toolchain_library {
-	name: "libclang_rt.builtins-x86_64-android",
-	defaults: ["linux_bionic_supported"],
-	vendor_available: true,
-	vendor_ramdisk_available: true,
-	product_available: true,
-	recovery_available: true,
-	native_bridge_supported: true,
-	src: "",
+    name: "libclang_rt.builtins-x86_64-android",
+    defaults: ["linux_bionic_supported"],
+    vendor_available: true,
+    vendor_ramdisk_available: true,
+    product_available: true,
+    recovery_available: true,
+    native_bridge_supported: true,
+    src: "",
 }`
 )
 
 func TestCcLibraryStaticLoadStatement(t *testing.T) {
-	testCases := []struct {
-		bazelTargets           BazelTargets
-		expectedLoadStatements string
-	}{
-		{
-			bazelTargets: BazelTargets{
-				BazelTarget{
-					name:      "cc_library_static_target",
-					ruleClass: "cc_library_static",
-					// NOTE: No bzlLoadLocation for native rules
-				},
-			},
-			expectedLoadStatements: ``,
-		},
-	}
+    testCases := []struct {
+        bazelTargets           BazelTargets
+        expectedLoadStatements string
+    }{
+        {
+            bazelTargets: BazelTargets{
+                BazelTarget{
+                    name:      "cc_library_static_target",
+                    ruleClass: "cc_library_static",
+                    // NOTE: No bzlLoadLocation for native rules
+                },
+            },
+            expectedLoadStatements: ``,
+        },
+    }
 
-	for _, testCase := range testCases {
-		actual := testCase.bazelTargets.LoadStatements()
-		expected := testCase.expectedLoadStatements
-		if actual != expected {
-			t.Fatalf("Expected load statements to be %s, got %s", expected, actual)
-		}
-	}
+    for _, testCase := range testCases {
+        actual := testCase.bazelTargets.LoadStatements()
+        expected := testCase.expectedLoadStatements
+        if actual != expected {
+            t.Fatalf("Expected load statements to be %s, got %s", expected, actual)
+        }
+    }
 
 }
 
 func TestCcLibraryStaticBp2Build(t *testing.T) {
-	testCases := []struct {
-		description                        string
-		moduleTypeUnderTest                string
-		moduleTypeUnderTestFactory         android.ModuleFactory
-		moduleTypeUnderTestBp2BuildMutator func(android.TopDownMutatorContext)
-		preArchMutators                    []android.RegisterMutatorFunc
-		depsMutators                       []android.RegisterMutatorFunc
-		bp                                 string
-		expectedBazelTargets               []string
-		filesystem                         map[string]string
-		dir                                string
-	}{
-		{
-			description:                        "cc_library_static test",
-			moduleTypeUnderTest:                "cc_library_static",
-			moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
-			filesystem: map[string]string{
-				// NOTE: include_dir headers *should not* appear in Bazel hdrs later (?)
-				"include_dir_1/include_dir_1_a.h": "",
-				"include_dir_1/include_dir_1_b.h": "",
-				"include_dir_2/include_dir_2_a.h": "",
-				"include_dir_2/include_dir_2_b.h": "",
-				// NOTE: local_include_dir headers *should not* appear in Bazel hdrs later (?)
-				"local_include_dir_1/local_include_dir_1_a.h": "",
-				"local_include_dir_1/local_include_dir_1_b.h": "",
-				"local_include_dir_2/local_include_dir_2_a.h": "",
-				"local_include_dir_2/local_include_dir_2_b.h": "",
-				// NOTE: export_include_dir headers *should* appear in Bazel hdrs later
-				"export_include_dir_1/export_include_dir_1_a.h": "",
-				"export_include_dir_1/export_include_dir_1_b.h": "",
-				"export_include_dir_2/export_include_dir_2_a.h": "",
-				"export_include_dir_2/export_include_dir_2_b.h": "",
-				// NOTE: Soong implicitly includes headers in the current directory
-				"implicit_include_1.h": "",
-				"implicit_include_2.h": "",
-			},
-			bp: soongCcLibraryStaticPreamble + `
+    testCases := []struct {
+        description                        string
+        moduleTypeUnderTest                string
+        moduleTypeUnderTestFactory         android.ModuleFactory
+        moduleTypeUnderTestBp2BuildMutator func(android.TopDownMutatorContext)
+        preArchMutators                    []android.RegisterMutatorFunc
+        depsMutators                       []android.RegisterMutatorFunc
+        bp                                 string
+        expectedBazelTargets               []string
+        filesystem                         map[string]string
+        dir                                string
+    }{
+        {
+            description:                        "cc_library_static test",
+            moduleTypeUnderTest:                "cc_library_static",
+            moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
+            filesystem: map[string]string{
+                // NOTE: include_dir headers *should not* appear in Bazel hdrs later (?)
+                "include_dir_1/include_dir_1_a.h": "",
+                "include_dir_1/include_dir_1_b.h": "",
+                "include_dir_2/include_dir_2_a.h": "",
+                "include_dir_2/include_dir_2_b.h": "",
+                // NOTE: local_include_dir headers *should not* appear in Bazel hdrs later (?)
+                "local_include_dir_1/local_include_dir_1_a.h": "",
+                "local_include_dir_1/local_include_dir_1_b.h": "",
+                "local_include_dir_2/local_include_dir_2_a.h": "",
+                "local_include_dir_2/local_include_dir_2_b.h": "",
+                // NOTE: export_include_dir headers *should* appear in Bazel hdrs later
+                "export_include_dir_1/export_include_dir_1_a.h": "",
+                "export_include_dir_1/export_include_dir_1_b.h": "",
+                "export_include_dir_2/export_include_dir_2_a.h": "",
+                "export_include_dir_2/export_include_dir_2_b.h": "",
+                // NOTE: Soong implicitly includes headers in the current directory
+                "implicit_include_1.h": "",
+                "implicit_include_2.h": "",
+            },
+            bp: soongCcLibraryStaticPreamble + `
 cc_library_headers {
     name: "header_lib_1",
     export_include_dirs: ["header_lib_1"],
@@ -173,7 +173,7 @@ cc_library_static {
 
     // TODO: Also support export_header_lib_headers
 }`,
-			expectedBazelTargets: []string{`cc_library_static(
+            expectedBazelTargets: []string{`cc_library_static(
     name = "foo_static",
     copts = [
         "-Dflag1",
@@ -224,36 +224,36 @@ cc_library_static {
     linkstatic = True,
     srcs = ["whole_static_lib_2.cc"],
 )`},
-		},
-		{
-			description:                        "cc_library_static subpackage test",
-			moduleTypeUnderTest:                "cc_library_static",
-			moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
-			filesystem: map[string]string{
-				// subpackage with subdirectory
-				"subpackage/Android.bp":                         "",
-				"subpackage/subpackage_header.h":                "",
-				"subpackage/subdirectory/subdirectory_header.h": "",
-				// subsubpackage with subdirectory
-				"subpackage/subsubpackage/Android.bp":                         "",
-				"subpackage/subsubpackage/subsubpackage_header.h":             "",
-				"subpackage/subsubpackage/subdirectory/subdirectory_header.h": "",
-				// subsubsubpackage with subdirectory
-				"subpackage/subsubpackage/subsubsubpackage/Android.bp":                         "",
-				"subpackage/subsubpackage/subsubsubpackage/subsubsubpackage_header.h":          "",
-				"subpackage/subsubpackage/subsubsubpackage/subdirectory/subdirectory_header.h": "",
-			},
-			bp: soongCcLibraryStaticPreamble + `
+        },
+        {
+            description:                        "cc_library_static subpackage test",
+            moduleTypeUnderTest:                "cc_library_static",
+            moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
+            filesystem: map[string]string{
+                // subpackage with subdirectory
+                "subpackage/Android.bp":                         "",
+                "subpackage/subpackage_header.h":                "",
+                "subpackage/subdirectory/subdirectory_header.h": "",
+                // subsubpackage with subdirectory
+                "subpackage/subsubpackage/Android.bp":                         "",
+                "subpackage/subsubpackage/subsubpackage_header.h":             "",
+                "subpackage/subsubpackage/subdirectory/subdirectory_header.h": "",
+                // subsubsubpackage with subdirectory
+                "subpackage/subsubpackage/subsubsubpackage/Android.bp":                         "",
+                "subpackage/subsubpackage/subsubsubpackage/subsubsubpackage_header.h":          "",
+                "subpackage/subsubpackage/subsubsubpackage/subdirectory/subdirectory_header.h": "",
+            },
+            bp: soongCcLibraryStaticPreamble + `
 cc_library_static {
     name: "foo_static",
     srcs: [
     ],
     include_dirs: [
-	"subpackage",
+    "subpackage",
     ],
 }`,
-			expectedBazelTargets: []string{`cc_library_static(
+            expectedBazelTargets: []string{`cc_library_static(
     name = "foo_static",
     copts = [
         "-Isubpackage",
@@ -261,62 +261,62 @@ cc_library_static {
     ],
     linkstatic = True,
 )`},
-		},
-		{
-			description:                        "cc_library_static export include dir",
-			moduleTypeUnderTest:                "cc_library_static",
-			moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
-			filesystem: map[string]string{
-				// subpackage with subdirectory
-				"subpackage/Android.bp":                         "",
-				"subpackage/subpackage_header.h":                "",
-				"subpackage/subdirectory/subdirectory_header.h": "",
-			},
-			bp: soongCcLibraryStaticPreamble + `
+        },
+        {
+            description:                        "cc_library_static export include dir",
+            moduleTypeUnderTest:                "cc_library_static",
+            moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
+            filesystem: map[string]string{
+                // subpackage with subdirectory
+                "subpackage/Android.bp":                         "",
+                "subpackage/subpackage_header.h":                "",
+                "subpackage/subdirectory/subdirectory_header.h": "",
+            },
+            bp: soongCcLibraryStaticPreamble + `
 cc_library_static {
     name: "foo_static",
     export_include_dirs: ["subpackage"],
 }`,
-			expectedBazelTargets: []string{`cc_library_static(
+            expectedBazelTargets: []string{`cc_library_static(
     name = "foo_static",
     copts = ["-I."],
     includes = ["subpackage"],
     linkstatic = True,
 )`},
-		},
-		{
-			description:                        "cc_library_static export system include dir",
-			moduleTypeUnderTest:                "cc_library_static",
-			moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
-			filesystem: map[string]string{
-				// subpackage with subdirectory
-				"subpackage/Android.bp":                         "",
-				"subpackage/subpackage_header.h":                "",
-				"subpackage/subdirectory/subdirectory_header.h": "",
-			},
-			bp: soongCcLibraryStaticPreamble + `
+        },
+        {
+            description:                        "cc_library_static export system include dir",
+            moduleTypeUnderTest:                "cc_library_static",
+            moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
+            filesystem: map[string]string{
+                // subpackage with subdirectory
+                "subpackage/Android.bp":                         "",
+                "subpackage/subpackage_header.h":                "",
+                "subpackage/subdirectory/subdirectory_header.h": "",
+            },
+            bp: soongCcLibraryStaticPreamble + `
 cc_library_static {
     name: "foo_static",
     export_system_include_dirs: ["subpackage"],
 }`,
-			expectedBazelTargets: []string{`cc_library_static(
+            expectedBazelTargets: []string{`cc_library_static(
     name = "foo_static",
     copts = ["-I."],
     includes = ["subpackage"],
     linkstatic = True,
 )`},
-		},
-		{
-			description:                        "cc_library_static include_dirs, local_include_dirs, export_include_dirs (b/183742505)",
-			moduleTypeUnderTest:                "cc_library_static",
-			moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
-			dir:                                "subpackage",
-			filesystem: map[string]string{
-				// subpackage with subdirectory
-				"subpackage/Android.bp": `
+        },
+        {
+            description:                        "cc_library_static include_dirs, local_include_dirs, export_include_dirs (b/183742505)",
+            moduleTypeUnderTest:                "cc_library_static",
+            moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
+            dir:                                "subpackage",
+            filesystem: map[string]string{
+                // subpackage with subdirectory
+                "subpackage/Android.bp": `
 cc_library_static {
     name: "foo_static",
     // include_dirs are workspace/root relative
@@ -330,14 +330,14 @@ cc_library_static {
     include_build_directory: true,
     bazel_module: { bp2build_available: true },
 }`,
-				"subpackage/subsubpackage/header.h":          "",
-				"subpackage/subsubpackage2/header.h":         "",
-				"subpackage/exported_subsubpackage/header.h": "",
-				"subpackage2/header.h":                       "",
-				"subpackage3/subsubpackage/header.h":         "",
-			},
-			bp: soongCcLibraryStaticPreamble,
-			expectedBazelTargets: []string{`cc_library_static(
+                "subpackage/subsubpackage/header.h":          "",
+                "subpackage/subsubpackage2/header.h":         "",
+                "subpackage/exported_subsubpackage/header.h": "",
+                "subpackage2/header.h":                       "",
+                "subpackage3/subsubpackage/header.h":         "",
+            },
+            bp: soongCcLibraryStaticPreamble,
+            expectedBazelTargets: []string{`cc_library_static(
     name = "foo_static",
     copts = [
         "-Isubpackage/subsubpackage",
@@ -349,26 +349,26 @@ cc_library_static {
     includes = ["./exported_subsubpackage"],
     linkstatic = True,
 )`},
-		},
-		{
-			description:                        "cc_library_static include_build_directory disabled",
-			moduleTypeUnderTest:                "cc_library_static",
-			moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
-			filesystem: map[string]string{
-				// subpackage with subdirectory
-				"subpackage/Android.bp":                         "",
-				"subpackage/subpackage_header.h":                "",
-				"subpackage/subdirectory/subdirectory_header.h": "",
-			},
-			bp: soongCcLibraryStaticPreamble + `
+        },
+        {
+            description:                        "cc_library_static include_build_directory disabled",
+            moduleTypeUnderTest:                "cc_library_static",
+            moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
+            filesystem: map[string]string{
+                // subpackage with subdirectory
+                "subpackage/Android.bp":                         "",
+                "subpackage/subpackage_header.h":                "",
+                "subpackage/subdirectory/subdirectory_header.h": "",
+            },
+            bp: soongCcLibraryStaticPreamble + `
 cc_library_static {
     name: "foo_static",
     include_dirs: ["subpackage"], // still used, but local_include_dirs is recommended
     local_include_dirs: ["subpackage2"],
     include_build_directory: false,
 }`,
-			expectedBazelTargets: []string{`cc_library_static(
+            expectedBazelTargets: []string{`cc_library_static(
     name = "foo_static",
     copts = [
         "-Isubpackage",
@@ -376,28 +376,28 @@ cc_library_static {
     ],
     linkstatic = True,
 )`},
-		},
-		{
-			description:                        "cc_library_static include_build_directory enabled",
-			moduleTypeUnderTest:                "cc_library_static",
-			moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
-			filesystem: map[string]string{
-				// subpackage with subdirectory
-				"subpackage/Android.bp":                         "",
-				"subpackage/subpackage_header.h":                "",
-				"subpackage2/Android.bp":                        "",
-				"subpackage2/subpackage2_header.h":              "",
-				"subpackage/subdirectory/subdirectory_header.h": "",
-			},
-			bp: soongCcLibraryStaticPreamble + `
+        },
+        {
+            description:                        "cc_library_static include_build_directory enabled",
+            moduleTypeUnderTest:                "cc_library_static",
+            moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
+            filesystem: map[string]string{
+                // subpackage with subdirectory
+                "subpackage/Android.bp":                         "",
+                "subpackage/subpackage_header.h":                "",
+                "subpackage2/Android.bp":                        "",
+                "subpackage2/subpackage2_header.h":              "",
+                "subpackage/subdirectory/subdirectory_header.h": "",
+            },
+            bp: soongCcLibraryStaticPreamble + `
 cc_library_static {
     name: "foo_static",
     include_dirs: ["subpackage"], // still used, but local_include_dirs is recommended
     local_include_dirs: ["subpackage2"],
     include_build_directory: true,
 }`,
-			expectedBazelTargets: []string{`cc_library_static(
+            expectedBazelTargets: []string{`cc_library_static(
     name = "foo_static",
     copts = [
         "-Isubpackage",
@@ -406,22 +406,22 @@ cc_library_static {
     ],
     linkstatic = True,
 )`},
-		},
-		{
-			description:                        "cc_library_static arch-specific static_libs",
-			moduleTypeUnderTest:                "cc_library_static",
-			moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
-			depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
-			filesystem:                         map[string]string{},
-			bp: soongCcLibraryStaticPreamble + `
+        },
+        {
+            description:                        "cc_library_static arch-specific static_libs",
+            moduleTypeUnderTest:                "cc_library_static",
+            moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
+            depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
+            filesystem:                         map[string]string{},
+            bp: soongCcLibraryStaticPreamble + `
 cc_library_static { name: "static_dep" }
 cc_library_static { name: "static_dep2" }
 cc_library_static {
     name: "foo_static",
     arch: { arm64: { static_libs: ["static_dep"], whole_static_libs: ["static_dep2"] } },
 }`,
-			expectedBazelTargets: []string{`cc_library_static(
+            expectedBazelTargets: []string{`cc_library_static(
     name = "foo_static",
     copts = ["-I."],
     deps = select({
@@ -442,22 +442,22 @@ cc_library_static {
     copts = ["-I."],
     linkstatic = True,
 )`},
-		},
-		{
-			description:                        "cc_library_static os-specific static_libs",
-			moduleTypeUnderTest:                "cc_library_static",
-			moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
-			depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
-			filesystem:                         map[string]string{},
-			bp: soongCcLibraryStaticPreamble + `
+        },
+        {
+            description:                        "cc_library_static os-specific static_libs",
+            moduleTypeUnderTest:                "cc_library_static",
+            moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
+            depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
+            filesystem:                         map[string]string{},
+            bp: soongCcLibraryStaticPreamble + `
 cc_library_static { name: "static_dep" }
 cc_library_static { name: "static_dep2" }
 cc_library_static {
     name: "foo_static",
     target: { android: { static_libs: ["static_dep"], whole_static_libs: ["static_dep2"] } },
 }`,
-			expectedBazelTargets: []string{`cc_library_static(
+            expectedBazelTargets: []string{`cc_library_static(
     name = "foo_static",
     copts = ["-I."],
     deps = select({
@@ -478,15 +478,15 @@ cc_library_static {
     copts = ["-I."],
     linkstatic = True,
 )`},
-		},
-		{
-			description:                        "cc_library_static base, arch and os-specific static_libs",
-			moduleTypeUnderTest:                "cc_library_static",
-			moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
-			depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
-			filesystem:                         map[string]string{},
-			bp: soongCcLibraryStaticPreamble + `
+        },
+        {
+            description:                        "cc_library_static base, arch and os-specific static_libs",
+            moduleTypeUnderTest:                "cc_library_static",
+            moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
+            depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
+            filesystem:                         map[string]string{},
+            bp: soongCcLibraryStaticPreamble + `
 cc_library_static { name: "static_dep" }
 cc_library_static { name: "static_dep2" }
 cc_library_static { name: "static_dep3" }
@@ -498,7 +498,7 @@ cc_library_static {
     target: { android: { static_libs: ["static_dep3"] } },
     arch: { arm64: { static_libs: ["static_dep4"] } },
 }`,
-			expectedBazelTargets: []string{`cc_library_static(
+            expectedBazelTargets: []string{`cc_library_static(
     name = "foo_static",
     copts = ["-I."],
     deps = [":static_dep"] + select({
@@ -527,25 +527,25 @@ cc_library_static {
     copts = ["-I."],
     linkstatic = True,
 )`},
-		},
-		{
-			description:                        "cc_library_static simple exclude_srcs",
-			moduleTypeUnderTest:                "cc_library_static",
-			moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
-			depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
-			filesystem: map[string]string{
-				"common.c":       "",
-				"foo-a.c":        "",
-				"foo-excluded.c": "",
-			},
-			bp: soongCcLibraryStaticPreamble + `
+        },
+        {
+            description:                        "cc_library_static simple exclude_srcs",
+            moduleTypeUnderTest:                "cc_library_static",
+            moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
+            depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
+            filesystem: map[string]string{
+                "common.c":       "",
+                "foo-a.c":        "",
+                "foo-excluded.c": "",
+            },
+            bp: soongCcLibraryStaticPreamble + `
 cc_library_static {
     name: "foo_static",
     srcs: ["common.c", "foo-*.c"],
     exclude_srcs: ["foo-excluded.c"],
 }`,
-			expectedBazelTargets: []string{`cc_library_static(
+            expectedBazelTargets: []string{`cc_library_static(
     name = "foo_static",
     copts = ["-I."],
     linkstatic = True,
@@ -554,24 +554,24 @@ cc_library_static {
         "foo-a.c",
     ],
 )`},
-		},
-		{
-			description:                        "cc_library_static one arch specific srcs",
-			moduleTypeUnderTest:                "cc_library_static",
-			moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
-			depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
-			filesystem: map[string]string{
-				"common.c":  "",
-				"foo-arm.c": "",
-			},
-			bp: soongCcLibraryStaticPreamble + `
+        },
+        {
+            description:                        "cc_library_static one arch specific srcs",
+            moduleTypeUnderTest:                "cc_library_static",
+            moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
+            depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
+            filesystem: map[string]string{
+                "common.c":  "",
+                "foo-arm.c": "",
+            },
+            bp: soongCcLibraryStaticPreamble + `
 cc_library_static {
     name: "foo_static",
     srcs: ["common.c"],
     arch: { arm: { srcs: ["foo-arm.c"] } }
 }`,
-			expectedBazelTargets: []string{`cc_library_static(
+            expectedBazelTargets: []string{`cc_library_static(
     name = "foo_static",
     copts = ["-I."],
     linkstatic = True,
@@ -580,20 +580,20 @@ cc_library_static {
         "//conditions:default": [],
     }),
 )`},
-		},
-		{
-			description:                        "cc_library_static one arch specific srcs and exclude_srcs",
-			moduleTypeUnderTest:                "cc_library_static",
-			moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
-			depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
-			filesystem: map[string]string{
-				"common.c":           "",
-				"for-arm.c":          "",
-				"not-for-arm.c":      "",
-				"not-for-anything.c": "",
-			},
-			bp: soongCcLibraryStaticPreamble + `
+        },
+        {
+            description:                        "cc_library_static one arch specific srcs and exclude_srcs",
+            moduleTypeUnderTest:                "cc_library_static",
+            moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
+            depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
+            filesystem: map[string]string{
+                "common.c":           "",
+                "for-arm.c":          "",
+                "not-for-arm.c":      "",
+                "not-for-anything.c": "",
+            },
+            bp: soongCcLibraryStaticPreamble + `
 cc_library_static {
     name: "foo_static",
     srcs: ["common.c", "not-for-*.c"],
@@ -602,7 +602,7 @@ cc_library_static {
         arm: { srcs: ["for-arm.c"], exclude_srcs: ["not-for-arm.c"] },
     },
 }`,
-			expectedBazelTargets: []string{`cc_library_static(
+            expectedBazelTargets: []string{`cc_library_static(
     name = "foo_static",
     copts = ["-I."],
     linkstatic = True,
@@ -611,69 +611,82 @@ cc_library_static {
         "//conditions:default": ["not-for-arm.c"],
     }),
 )`},
-		},
-		{
-			description:                        "cc_library_static arch specific exclude_srcs for 2 architectures",
-			moduleTypeUnderTest:                "cc_library_static",
-			moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
-			depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
-			filesystem: map[string]string{
-				"common.c":      "",
-				"for-arm.c":     "",
-				"for-x86.c":     "",
-				"not-for-arm.c": "",
-				"not-for-x86.c": "",
-			},
-			bp: soongCcLibraryStaticPreamble + `
+        },
+        {
+            description:                        "cc_library_static arch specific exclude_srcs for 2 architectures",
+            moduleTypeUnderTest:                "cc_library_static",
+            moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
+            depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
+            filesystem: map[string]string{
+                "common.c":      "",
+                "for-arm.c":     "",
+                "for-riscv64.c": "",
+                "for-x86.c":     "",
+                "not-for-arm.c": "",
+                "not-for-riscv64.c": "",
+                "not-for-x86.c": "",
+            },
+            bp: soongCcLibraryStaticPreamble + `
 cc_library_static {
     name: "foo_static",
     srcs: ["common.c", "not-for-*.c"],
     exclude_srcs: ["not-for-everything.c"],
     arch: {
         arm: { srcs: ["for-arm.c"], exclude_srcs: ["not-for-arm.c"] },
+        riscv64: { srcs: ["for-riscv64.c"], exclude_srcs : ["not-for-riscv64.c"] },
         x86: { srcs: ["for-x86.c"], exclude_srcs: ["not-for-x86.c"] },
     },
 } `,
-			expectedBazelTargets: []string{`cc_library_static(
+            expectedBazelTargets: []string{`cc_library_static(
     name = "foo_static",
     copts = ["-I."],
     linkstatic = True,
     srcs = ["common.c"] + select({
         "//build/bazel/platforms/arch:arm": [
             "for-arm.c",
+            "not-for-riscv64.c",
+            "not-for-x86.c",
+        ],
+        "//build/bazel/platforms/arch:riscv64": [
+            "for-riscv64.c",
+            "not-for-arm.c",
             "not-for-x86.c",
         ],
         "//build/bazel/platforms/arch:x86": [
             "for-x86.c",
             "not-for-arm.c",
+            "not-for-riscv64.c",
         ],
         "//conditions:default": [
             "not-for-arm.c",
+            "not-for-riscv64.c",
             "not-for-x86.c",
         ],
     }),
 )`},
-		},
-		{
-			description:                        "cc_library_static arch specific exclude_srcs for 4 architectures",
-			moduleTypeUnderTest:                "cc_library_static",
-			moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
-			depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
-			filesystem: map[string]string{
-				"common.c":             "",
-				"for-arm.c":            "",
-				"for-arm64.c":          "",
-				"for-x86.c":            "",
-				"for-x86_64.c":         "",
-				"not-for-arm.c":        "",
-				"not-for-arm64.c":      "",
-				"not-for-x86.c":        "",
-				"not-for-x86_64.c":     "",
-				"not-for-everything.c": "",
-			},
-			bp: soongCcLibraryStaticPreamble + `
+        },
+        {
+            description:                        "cc_library_static arch specific exclude_srcs for 4 architectures",
+            moduleTypeUnderTest:                "cc_library_static",
+            moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
+            depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
+            filesystem: map[string]string{
+                "common.c":             "",
+                "for-arm.c":            "",
+                "for-arm64.c":          "",
+                "for-riscv64.c":        "",
+                "for-x86.c":            "",
+                "for-x86_64.c":         "",
+                "not-for-arm.c":        "",
+                "not-for-arm64.c":      "",
+                "not-for-riscv64.c":    "",
+                "not-for-x86.c":        "",
+                "not-for-x86_64.c":     "",
+                "not-for-everything.c": "",
+            },
+            bp: soongCcLibraryStaticPreamble + `
 cc_library_static {
     name: "foo_static",
     srcs: ["common.c", "not-for-*.c"],
@@ -681,11 +694,12 @@ cc_library_static {
     arch: {
         arm: { srcs: ["for-arm.c"], exclude_srcs: ["not-for-arm.c"] },
         arm64: { srcs: ["for-arm64.c"], exclude_srcs: ["not-for-arm64.c"] },
+        riscv64: { srcs: ["for-riscv64.c"], exclude_srcs: ["not-for-riscv64.c"] },
         x86: { srcs: ["for-x86.c"], exclude_srcs: ["not-for-x86.c"] },
         x86_64: { srcs: ["for-x86_64.c"], exclude_srcs: ["not-for-x86_64.c"] },
-	},
+    },
 } `,
-			expectedBazelTargets: []string{`cc_library_static(
+            expectedBazelTargets: []string{`cc_library_static(
     name = "foo_static",
     copts = ["-I."],
     linkstatic = True,
@@ -693,12 +707,21 @@ cc_library_static {
         "//build/bazel/platforms/arch:arm": [
             "for-arm.c",
             "not-for-arm64.c",
+            "not-for-riscv64.c",
             "not-for-x86.c",
             "not-for-x86_64.c",
         ],
         "//build/bazel/platforms/arch:arm64": [
             "for-arm64.c",
             "not-for-arm.c",
+            "not-for-riscv64.c",
+            "not-for-x86.c",
+            "not-for-x86_64.c",
+        ],
+        "//build/bazel/platforms/arch:riscv64": [
+            "for-riscv64.c",
+            "not-for-arm.c",
+            "not-for-arm64.c",
             "not-for-x86.c",
             "not-for-x86_64.c",
         ],
@@ -706,37 +729,40 @@ cc_library_static {
             "for-x86.c",
             "not-for-arm.c",
             "not-for-arm64.c",
+            "not-for-riscv64.c",
             "not-for-x86_64.c",
         ],
         "//build/bazel/platforms/arch:x86_64": [
             "for-x86_64.c",
             "not-for-arm.c",
             "not-for-arm64.c",
+            "not-for-riscv64.c",
             "not-for-x86.c",
         ],
         "//conditions:default": [
             "not-for-arm.c",
             "not-for-arm64.c",
+            "not-for-riscv64.c",
             "not-for-x86.c",
             "not-for-x86_64.c",
         ],
     }),
 )`},
-		},
-		{
-			description:                        "cc_library_static multiple dep same name panic",
-			moduleTypeUnderTest:                "cc_library_static",
-			moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
-			depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
-			filesystem:                         map[string]string{},
-			bp: soongCcLibraryStaticPreamble + `
+        },
+        {
+            description:                        "cc_library_static multiple dep same name panic",
+            moduleTypeUnderTest:                "cc_library_static",
+            moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
+            depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
+            filesystem:                         map[string]string{},
+            bp: soongCcLibraryStaticPreamble + `
 cc_library_static { name: "static_dep" }
 cc_library_static {
     name: "foo_static",
     static_libs: ["static_dep", "static_dep"],
 }`,
-			expectedBazelTargets: []string{`cc_library_static(
+            expectedBazelTargets: []string{`cc_library_static(
     name = "foo_static",
     copts = ["-I."],
     deps = [":static_dep"],
@@ -746,19 +772,19 @@ cc_library_static {
     copts = ["-I."],
     linkstatic = True,
 )`},
-		},
-		{
-			description:                        "cc_library_static 1 multilib srcs and exclude_srcs",
-			moduleTypeUnderTest:                "cc_library_static",
-			moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
-			depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
-			filesystem: map[string]string{
-				"common.c":        "",
-				"for-lib32.c":     "",
-				"not-for-lib32.c": "",
-			},
-			bp: soongCcLibraryStaticPreamble + `
+        },
+        {
+            description:                        "cc_library_static 1 multilib srcs and exclude_srcs",
+            moduleTypeUnderTest:                "cc_library_static",
+            moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
+            depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
+            filesystem: map[string]string{
+                "common.c":        "",
+                "for-lib32.c":     "",
+                "not-for-lib32.c": "",
+            },
+            bp: soongCcLibraryStaticPreamble + `
 cc_library_static {
     name: "foo_static",
     srcs: ["common.c", "not-for-*.c"],
@@ -766,7 +792,7 @@ cc_library_static {
         lib32: { srcs: ["for-lib32.c"], exclude_srcs: ["not-for-lib32.c"] },
     },
 } `,
-			expectedBazelTargets: []string{`cc_library_static(
+            expectedBazelTargets: []string{`cc_library_static(
     name = "foo_static",
     copts = ["-I."],
     linkstatic = True,
@@ -776,21 +802,21 @@ cc_library_static {
         "//conditions:default": ["not-for-lib32.c"],
     }),
 )`},
-		},
-		{
-			description:                        "cc_library_static 2 multilib srcs and exclude_srcs",
-			moduleTypeUnderTest:                "cc_library_static",
-			moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
-			depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
-			filesystem: map[string]string{
-				"common.c":        "",
-				"for-lib32.c":     "",
-				"for-lib64.c":     "",
-				"not-for-lib32.c": "",
-				"not-for-lib64.c": "",
-			},
-			bp: soongCcLibraryStaticPreamble + `
+        },
+        {
+            description:                        "cc_library_static 2 multilib srcs and exclude_srcs",
+            moduleTypeUnderTest:                "cc_library_static",
+            moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
+            depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
+            filesystem: map[string]string{
+                "common.c":        "",
+                "for-lib32.c":     "",
+                "for-lib64.c":     "",
+                "not-for-lib32.c": "",
+                "not-for-lib64.c": "",
+            },
+            bp: soongCcLibraryStaticPreamble + `
 cc_library_static {
     name: "foo_static2",
     srcs: ["common.c", "not-for-*.c"],
@@ -799,7 +825,7 @@ cc_library_static {
         lib64: { srcs: ["for-lib64.c"], exclude_srcs: ["not-for-lib64.c"] },
     },
 } `,
-			expectedBazelTargets: []string{`cc_library_static(
+            expectedBazelTargets: []string{`cc_library_static(
     name = "foo_static2",
     copts = ["-I."],
     linkstatic = True,
@@ -812,6 +838,10 @@ cc_library_static {
             "for-lib64.c",
             "not-for-lib32.c",
         ],
+        "//build/bazel/platforms/arch:riscv64": [
+            "for-lib64.c",
+            "not-for-lib32.c",
+        ],
         "//build/bazel/platforms/arch:x86": [
             "for-lib32.c",
             "not-for-lib64.c",
@@ -826,30 +856,32 @@ cc_library_static {
         ],
     }),
 )`},
-		},
-		{
-			description:                        "cc_library_static arch and multilib srcs and exclude_srcs",
-			moduleTypeUnderTest:                "cc_library_static",
-			moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
-			moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
-			depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
-			filesystem: map[string]string{
-				"common.c":             "",
-				"for-arm.c":            "",
-				"for-arm64.c":          "",
-				"for-x86.c":            "",
-				"for-x86_64.c":         "",
-				"for-lib32.c":          "",
-				"for-lib64.c":          "",
-				"not-for-arm.c":        "",
-				"not-for-arm64.c":      "",
-				"not-for-x86.c":        "",
-				"not-for-x86_64.c":     "",
-				"not-for-lib32.c":      "",
-				"not-for-lib64.c":      "",
-				"not-for-everything.c": "",
-			},
-			bp: soongCcLibraryStaticPreamble + `
+        },
+        {
+            description:                        "cc_library_static arch and multilib srcs and exclude_srcs",
+            moduleTypeUnderTest:                "cc_library_static",
+            moduleTypeUnderTestFactory:         cc.LibraryStaticFactory,
+            moduleTypeUnderTestBp2BuildMutator: cc.CcLibraryStaticBp2Build,
+            depsMutators:                       []android.RegisterMutatorFunc{cc.RegisterDepsBp2Build},
+            filesystem: map[string]string{
+                "common.c":             "",
+                "for-arm.c":            "",
+                "for-arm64.c":          "",
+                "for-riscv64.c":        "",
+                "for-x86.c":            "",
+                "for-x86_64.c":         "",
+                "for-lib32.c":          "",
+                "for-lib64.c":          "",
+                "not-for-arm.c":        "",
+                "not-for-arm64.c":      "",
+                "not-for-riscv64.c":    "",
+                "not-for-x86.c":        "",
+                "not-for-x86_64.c":     "",
+                "not-for-lib32.c":      "",
+                "not-for-lib64.c":      "",
+                "not-for-everything.c": "",
+            },
+            bp: soongCcLibraryStaticPreamble + `
 cc_library_static {
    name: "foo_static3",
    srcs: ["common.c", "not-for-*.c"],
@@ -857,6 +889,7 @@ cc_library_static {
    arch: {
        arm: { srcs: ["for-arm.c"], exclude_srcs: ["not-for-arm.c"] },
        arm64: { srcs: ["for-arm64.c"], exclude_srcs: ["not-for-arm64.c"] },
+       riscv64: { srcs: ["for-riscv64.c"], exclude_srcs: ["not-for-riscv64.c"] },
        x86: { srcs: ["for-x86.c"], exclude_srcs: ["not-for-x86.c"] },
        x86_64: { srcs: ["for-x86_64.c"], exclude_srcs: ["not-for-x86_64.c"] },
    },
@@ -865,7 +898,7 @@ cc_library_static {
        lib64: { srcs: ["for-lib64.c"], exclude_srcs: ["not-for-lib64.c"] },
    },
 }`,
-			expectedBazelTargets: []string{`cc_library_static(
+            expectedBazelTargets: []string{`cc_library_static(
     name = "foo_static3",
     copts = ["-I."],
     linkstatic = True,
@@ -875,6 +908,7 @@ cc_library_static {
             "for-lib32.c",
             "not-for-arm64.c",
             "not-for-lib64.c",
+            "not-for-riscv64.c",
             "not-for-x86.c",
             "not-for-x86_64.c",
         ],
@@ -882,6 +916,16 @@ cc_library_static {
             "for-arm64.c",
             "for-lib64.c",
             "not-for-arm.c",
+            "not-for-lib32.c",
+            "not-for-riscv64.c",
+            "not-for-x86.c",
+            "not-for-x86_64.c",
+        ],
+        "//build/bazel/platforms/arch:riscv64": [
+            "for-lib64.c",
+            "for-riscv64.c",
+            "not-for-arm.c",
+            "not-for-arm64.c",
             "not-for-lib32.c",
             "not-for-x86.c",
             "not-for-x86_64.c",
@@ -892,6 +936,7 @@ cc_library_static {
             "not-for-arm.c",
             "not-for-arm64.c",
             "not-for-lib64.c",
+            "not-for-riscv64.c",
             "not-for-x86_64.c",
         ],
         "//build/bazel/platforms/arch:x86_64": [
@@ -900,6 +945,7 @@ cc_library_static {
             "not-for-arm.c",
             "not-for-arm64.c",
             "not-for-lib32.c",
+            "not-for-riscv64.c",
             "not-for-x86.c",
         ],
         "//conditions:default": [
@@ -907,69 +953,70 @@ cc_library_static {
             "not-for-arm64.c",
             "not-for-lib32.c",
             "not-for-lib64.c",
+            "not-for-riscv64.c",
             "not-for-x86.c",
             "not-for-x86_64.c",
         ],
     }),
 )`},
-		},
-	}
+        },
+    }
 
-	dir := "."
-	for _, testCase := range testCases {
-		filesystem := make(map[string][]byte)
-		toParse := []string{
-			"Android.bp",
-		}
-		for f, content := range testCase.filesystem {
-			if strings.HasSuffix(f, "Android.bp") {
-				toParse = append(toParse, f)
-			}
-			filesystem[f] = []byte(content)
-		}
-		config := android.TestConfig(buildDir, nil, testCase.bp, filesystem)
-		ctx := android.NewTestContext(config)
+    dir := "."
+    for _, testCase := range testCases {
+        filesystem := make(map[string][]byte)
+        toParse := []string{
+            "Android.bp",
+        }
+        for f, content := range testCase.filesystem {
+            if strings.HasSuffix(f, "Android.bp") {
+                toParse = append(toParse, f)
+            }
+            filesystem[f] = []byte(content)
+        }
+        config := android.TestConfig(buildDir, nil, testCase.bp, filesystem)
+        ctx := android.NewTestContext(config)
 
-		cc.RegisterCCBuildComponents(ctx)
-		ctx.RegisterModuleType("toolchain_library", cc.ToolchainLibraryFactory)
-		ctx.RegisterModuleType("cc_library_headers", cc.LibraryHeaderFactory)
+        cc.RegisterCCBuildComponents(ctx)
+        ctx.RegisterModuleType("toolchain_library", cc.ToolchainLibraryFactory)
+        ctx.RegisterModuleType("cc_library_headers", cc.LibraryHeaderFactory)
 
-		ctx.RegisterModuleType(testCase.moduleTypeUnderTest, testCase.moduleTypeUnderTestFactory)
-		for _, m := range testCase.depsMutators {
-			ctx.DepsBp2BuildMutators(m)
-		}
-		ctx.RegisterBp2BuildMutator(testCase.moduleTypeUnderTest, testCase.moduleTypeUnderTestBp2BuildMutator)
-		ctx.RegisterBp2BuildConfig(bp2buildConfig)
-		ctx.RegisterForBazelConversion()
+        ctx.RegisterModuleType(testCase.moduleTypeUnderTest, testCase.moduleTypeUnderTestFactory)
+        for _, m := range testCase.depsMutators {
+            ctx.DepsBp2BuildMutators(m)
+        }
+        ctx.RegisterBp2BuildMutator(testCase.moduleTypeUnderTest, testCase.moduleTypeUnderTestBp2BuildMutator)
+        ctx.RegisterBp2BuildConfig(bp2buildConfig)
+        ctx.RegisterForBazelConversion()
 
-		_, errs := ctx.ParseFileList(dir, toParse)
-		if Errored(t, testCase.description, errs) {
-			continue
-		}
-		_, errs = ctx.ResolveDependencies(config)
-		if Errored(t, testCase.description, errs) {
-			continue
-		}
+        _, errs := ctx.ParseFileList(dir, toParse)
+        if Errored(t, testCase.description, errs) {
+            continue
+        }
+        _, errs = ctx.ResolveDependencies(config)
+        if Errored(t, testCase.description, errs) {
+            continue
+        }
 
-		checkDir := dir
-		if testCase.dir != "" {
-			checkDir = testCase.dir
-		}
-		codegenCtx := NewCodegenContext(config, *ctx.Context, Bp2Build)
-		bazelTargets := generateBazelTargetsForDir(codegenCtx, checkDir)
-		if actualCount, expectedCount := len(bazelTargets), len(testCase.expectedBazelTargets); actualCount != expectedCount {
-			t.Errorf("%s: Expected %d bazel target, got %d", testCase.description, expectedCount, actualCount)
-		} else {
-			for i, target := range bazelTargets {
-				if w, g := testCase.expectedBazelTargets[i], target.content; w != g {
-					t.Errorf(
-						"%s: Expected generated Bazel target to be '%s', got '%s'",
-						testCase.description,
-						w,
-						g,
-					)
-				}
-			}
-		}
-	}
+        checkDir := dir
+        if testCase.dir != "" {
+            checkDir = testCase.dir
+        }
+        codegenCtx := NewCodegenContext(config, *ctx.Context, Bp2Build)
+        bazelTargets := generateBazelTargetsForDir(codegenCtx, checkDir)
+        if actualCount, expectedCount := len(bazelTargets), len(testCase.expectedBazelTargets); actualCount != expectedCount {
+            t.Errorf("%s: Expected %d bazel target, got %d", testCase.description, expectedCount, actualCount)
+        } else {
+            for i, target := range bazelTargets {
+                if w, g := testCase.expectedBazelTargets[i], target.content; w != g {
+                    t.Errorf(
+                        "%s: Expected generated Bazel target to be '%s', got '%s'",
+                        testCase.description,
+                        w,
+                        g,
+                    )
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
link with https://github.com/aosp-riscv/platform_manifest/issues/1

Edited three files, made soong able to do the comparison with the new output after added risc-v support for the AOSP building process.